### PR TITLE
Backend/display posts on event tourism

### DIFF
--- a/app/Http/Controllers/Admin/PostsController.php
+++ b/app/Http/Controllers/Admin/PostsController.php
@@ -17,6 +17,9 @@ class PostsController extends Controller
                         ->orderBy('id', 'asc')
                         ->paginate(10);
 
+                       
+                        
+
         return view('admin.posts.posts-index', compact('all_posts'));
     }
 }

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -310,4 +310,11 @@ if ($request->hasFile('image')) {
 
        return redirect()->route('home')->with('success', 'Post deleted successfully.');
     }
+
+    public function showTourismPosts()
+{
+    $posts = Post::with('images')->where('type', 1)->get();
+    return view('display.tourism', compact('posts'));
+
+}
 }

--- a/app/Http/Controllers/RecommendationController.php
+++ b/app/Http/Controllers/RecommendationController.php
@@ -30,7 +30,7 @@ class RecommendationController extends Controller
     {
         // Get the existing recommendation category
     $recommendedCategory = $this->category->whereHas('recommendations')->first();
-
+$existingRecommendation = $this->recommendation->first();
     // Handling when categories are not found
     if (!$recommendedCategory) {
         return [
@@ -65,5 +65,7 @@ class RecommendationController extends Controller
         'recommendedCategory' => $recommendedCategory
     ];
     }
+
+
 
 }

--- a/app/Http/Controllers/admin/CategoryController.php
+++ b/app/Http/Controllers/admin/CategoryController.php
@@ -41,7 +41,7 @@ class CategoryController extends Controller
             $category->parent_id = $request->parent_id ?: null;
             $category->created_at = Carbon::now();
             $category->updated_at = Carbon::now();
-            $category->user_id = Auth::id();
+        
             
             $category->save();
             

--- a/public/css/events.css
+++ b/public/css/events.css
@@ -142,17 +142,50 @@ body {
   color: #2A3132;
 }
 
+.parent-category {
+  position: relative; /* 子カテゴリを親カテゴリに対して配置するためにpositionを設定 */
+}
+
+/* 子カテゴリの初期表示を非表示にする */
+.child-categories {
+  display: none;
+  position: absolute;
+  top: 100%; /* 親カテゴリの下に表示 */
+  left: 0;
+  background-color: white;
+  padding: 10px;
+  border: 1px solid #ccc;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2); /* 影をつけて見やすくする */
+  z-index: 1;
+  
+}
+
+.child-categories a {
+  display: block;
+  font-size: 10px; /* 小さめのフォントサイズ */
+  color: #333;
+  padding: 5px 10px;
+  text-decoration: none;
+  font-weight: normal;
+}
+
+
+
+
+/* 親カテゴリにホバーしたときに子カテゴリを表示 */
+.parent-category:hover .child-categories {
+  display: block;
+}
+
 /* category */
-.category {
+.categories {
   display: flex;
   justify-content: center;
   gap: 20px;
-  position: relative;
-  left: 70px;
 }
 
 /* category-link */
-.category a {
+.categories a {
   text-decoration: none;
   color: #000;
   padding: 15px 15px;
@@ -162,7 +195,7 @@ body {
 }
 
 /* category hover */
-.category a:hover {
+.categories a:hover {
   color: #007BFF; /* ホバー時の色を指定 */
 }
 
@@ -208,6 +241,7 @@ body {
 .small_post .card{
   box-shadow: 0px 4px 10px rgba(0, 0, 0, .25);
   margin-bottom: 60px;
+  height: 100%;
 }
 
 .small_post img {

--- a/public/css/tourism.css
+++ b/public/css/tourism.css
@@ -203,6 +203,7 @@ opacity: 0.8; /* 不透明度を下げる */
   margin-bottom: 60px;
   overflow: hidden;
   border-radius: 10px; /* 角を丸くする */
+  height: 100%;
 }
 
 .small_post img {

--- a/public/css/tourism.css
+++ b/public/css/tourism.css
@@ -135,16 +135,50 @@ opacity: 0.8; /* 不透明度を下げる */
   color: #2A3132;
 }
 
+.parent-category {
+  position: relative; /* 子カテゴリを親カテゴリに対して配置するためにpositionを設定 */
+}
+
+/* 子カテゴリの初期表示を非表示にする */
+.child-categories {
+  display: none;
+  position: absolute;
+  top: 100%; /* 親カテゴリの下に表示 */
+  left: 0;
+  background-color: white;
+  padding: 10px;
+  border: 1px solid #ccc;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2); /* 影をつけて見やすくする */
+  z-index: 1;
+  
+}
+
+.child-categories a {
+  display: block;
+  font-size: 10px; /* 小さめのフォントサイズ */
+  color: #333;
+  padding: 5px 10px;
+  text-decoration: none;
+  font-weight: normal;
+}
+
+
+
+
+/* 親カテゴリにホバーしたときに子カテゴリを表示 */
+.parent-category:hover .child-categories {
+  display: block;
+}
 
 /* category */
-.category {
+.categories {
   display: flex;
   justify-content: center;
   gap: 20px;
 }
 
 /* category-link */
-.category a {
+.categories a {
   text-decoration: none;
   color: #000;
   padding: 15px 15px;
@@ -154,7 +188,7 @@ opacity: 0.8; /* 不透明度を下げる */
 }
 
 /* category hover */
-.category a:hover {
+.categories a:hover {
   color: #007BFF; /* ホバー時の色を指定 */
 }
 
@@ -225,9 +259,14 @@ opacity: 0.8; /* 不透明度を下げる */
 .post_text button {
   height: 40px; /* 高さを調整 */
   padding: 10px 15px; /* ボタンの内側の余白 */
-  background-color: #336B87 !important; /* ボタンの背景色 */
+  background-color: #336B87; /* ボタンの背景色 */
   color: #ffffff; /* ボタンのテキスト色 */
   border: none; /* ボタンの境界線を無効にする */
-  border-radius: 5px; /* 角を丸くする */
+  border-radius: 10px; /* 角を丸くする */
   cursor: pointer; /* カーソルをポインターに変更 */
+}
+
+.post_text a button:hover {
+    background-color: #90AFC5; /* ホバー時の背景色 */
+    color: #2A3132; /* ボタンのテキスト色 */
 }

--- a/resources/views/display/events.blade.php
+++ b/resources/views/display/events.blade.php
@@ -16,7 +16,7 @@
                
             
                  <div class="eventbar">
-                      <img src="images/eventbar.png" alt="Event Banner" class="banner-img">
+                      <img src="{{ asset('images/eventbar.png')}}" alt="Event Banner" class="banner-img">
                       <div class="banner-text">Event</div>
                  </div>
             </div> 
@@ -27,8 +27,9 @@
     <div class="row justify-content-center">
         <div class="col-md-9">
             <div class="spot-banner">
-                <a href="#">
-                    <img src="images/map.png" class="spot-banner-img mx-auto d-block" alt="map pictures">
+                <a href="{{route('map.page')}}">
+                    <img src="{{ asset('images/map.png')}}"
+                    class="spot-banner-img mx-auto d-block" alt="map pictures">
                     <div class="spot-banner-text">
                             <h2>Spots near You</h2>
                     </div>
@@ -44,17 +45,19 @@
                 </form>
             </div>
 
-            <!-- category part -->
-            <div class="category">
-                @php
-                    $categories = ['rainy day','with kid','couple','local','music'];
-                @endphp
-
-                @foreach ($categories as $category)
-                    <a href="#">{{$category}}</a>
+           <!-- category part -->
+           <div class="categories">
+    @foreach($parentCategories as $parent)
+        <div class="parent-category">
+            <a href="{{ route('events.category', ['category_id' => $parent->id]) }}">{{ $parent->name }}</a>
+            <div class="child-categories">
+                @foreach($parent->children as $child)
+                    <a href="{{ route('events.category', ['category_id' => $child->id]) }}">{{ $child->name }}</a>
                 @endforeach
-                <a href="#"><i class="fa-solid fa-ellipsis"></i></a>
             </div>
+        </div>
+    @endforeach
+</div>
         </div> 
 
         <!-- Calendar Section -->

--- a/resources/views/display/tourism.blade.php
+++ b/resources/views/display/tourism.blade.php
@@ -13,14 +13,14 @@
                      <img src="{{ asset('images/Group 316.png') }}" alt="Where To Go?" class="img-fluid mb-2">
                  </div>
                  <div class="tourismbar">
-                      <img src="images/tourismbar.png" alt="Tourism Banner" class="banner-img">
+                      <img src="{{asset('images/tourismbar.png')}}" alt="Tourism Banner" class="banner-img">
                       <div class="banner-text">Tourism</div>
                  </div>
             </div> 
     
             <div class="spot-banner">
-                <a href="#">
-                    <img src="images/map.png" class="spot-banner-img mx-auto d-block" alt="map pictures">
+                <a href="{{ route('map.page')}}">
+                    <img src="{{asset('images/map.png')}}" class="spot-banner-img mx-auto d-block" alt="map pictures">
                     <div class="spot-banner-text">
                             <h2>Spots near You</h2>
                             <div class="map-marker"></div>
@@ -38,16 +38,19 @@
             </div>
 
             <!-- category part -->
-            <div class="category">
-                @php
-                    $categories = ['rainy day','with kid','couple','local','music'];
-                @endphp
-
-                @foreach ($categories as $category)
-                    <a href="#">{{$category}}</a>
+            <div class="categories">
+                @foreach($parentCategories as $parent)
+                  <div class="parent-category">
+                        <a href="{{ route('tourism.category', ['category_id' => $parent->id]) }}">{{ $parent->name }}</a>
+                        <div class="child-categories">
+                              @foreach($parent->children as $child)
+                                 <a href="{{ route('tourism.category', ['category_id' => $child->id]) }}">{{ $child->name }}</a>
+                              @endforeach
+                      </div>
+                 </div>
                 @endforeach
-                <a href="#"><i class="fa-solid fa-ellipsis"></i></a>
             </div>
+
         </div>
     </div> 
     
@@ -66,6 +69,7 @@
            
 
     {{-- Posts Section --}}
+    
     
     @include('post-spot.tourism-posts')
 @endsection

--- a/resources/views/display/tourism.blade.php
+++ b/resources/views/display/tourism.blade.php
@@ -66,6 +66,7 @@
            
 
     {{-- Posts Section --}}
+    
     @include('post-spot.tourism-posts')
 @endsection
   

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -24,7 +24,7 @@
             <!-- Event and Tourism Page -->
             <div class="row mt-5">
                 <div class="col-md-6">
-                    <a href="{{ route('events') }}"> <!-- イベントページへのリンク -->
+                    <a href="{{ route('display.events') }}"> <!-- イベントページへのリンク -->
                         <div class="card page-link-card shadow-card">
                             <img src="{{ asset('images/event.jpg') }}" class="card-img-top" alt="Event Page Image">
                             <div class="card-body text-center">
@@ -34,7 +34,7 @@
                     </a>
                 </div>
                 <div class="col-md-6">
-                    <a href="{{ route('tourism') }}"> <!-- ツーリズムページへのリンク -->
+                    <a href="{{ route('display.tourism') }}"> <!-- ツーリズムページへのリンク -->
                         <div class="card page-link-card shadow-card">
                             <img src="{{ asset('images/tourism.jpg') }}" class="card-img-top" alt="Tourism Page Image">
                             <div class="card-body text-center">

--- a/resources/views/post-spot/event-posts.blade.php
+++ b/resources/views/post-spot/event-posts.blade.php
@@ -1,22 +1,93 @@
-
-
 <div class="show_posts">
+  <div class="container">
+     <div class="row">
+      <!-- レコメンド機能 recommend -->
+          <h3>Recommended Events Posts</h3>
+            @if($eventRecommendations->isEmpty())
+          <a href="{{ route('spot.show', $spot->id )}}" class="text-decoration-none">
+          <div class="col-12">
+               <p class="text-center text-danger">No recommendations available at the moment.</p>
+         </div>
+           <!-- card -->
+            @else
+            @foreach ($eventRecommendations->take(4) as $recommendation)
+         <div class="small_post col-md-3">
+         <div class="card">
+               <a href="{{ route('post.show', $recommendation->post->id) }}">
+                  <img src="{{ asset('storage/' . $recommendation->post->images->first()->image_url) }}" class="card-img-top" alt="Post Image">
+               </a>
+        <!-- card body -->
+        <div class="card-body">
+            <div class="row">
+                <div class="col-auto">
+                    <h5 class="fw-bolder">{{ $recommendation->post->title }}</h5>
+               </div>
+        </div>
+        <div class="row d-flex justify-content-end pe-2">
+                      {{-- Likes --}}
+                    <div class="col-auto">
+                      <form action="{{ route('post.like', $recommendation->post->id ?? 1) }}" method="POST">
+                        @csrf
+                        <button type="submit" class="btn btn-sm shadow-none p-0" aria-label="like">
+                            <i class="fa-regular fa-heart {{ $recommendation->post->isLiked() ? 'active' : '' }}" id="like-icon"></i>
+                        </button>
+                        <span class="count-text ms-1" id="like-count">{{ $recommendation->post->likes->count() }}</span>
+                     </form>
+            </div>
+            <div class="col-auto p-0">
+                      <form action="{{ route('post.favorite', $recommendation->post->id ?? 1) }}" method="POST">
+                        @csrf
+                        <button type="submit" class="btn btn-sm shadow-none p-0" aria-label="star">
+                            <i class="fa-regular fa-star {{ $recommendation->post->isFavorited ? 'active' : '' }}" id="favorite-icon"></i>
+                        </button>
+                        <span class="count-text ms-1" id="favorite-count">{{ $recommendation->post->favorites->count() }}</span>
+                      </form>
+                
+            </div>
+          
+     </div>
+
+    <div class="row">
+         <div class="col-auto mb-1">
+          @foreach ($recommendation->post->categories as $category)
+          @if ($category->id == $recommendedCategory->id) <!-- レコメンドされたカテゴリのみ表示 -->
+              <span class="badge bg-secondary bg-opacity-50 rounded-pill">{{ $category->name }}</span>
+           @endif
+          @endforeach
+        </div>
+     </div>
+
+ <!-- 投稿の本文を制限して表示 -->
+  <div class="post_text">
+     <p>{{ Str::limit($recommendation->post->comments, 50) }}</p>
+<a href="{{ route('post.show', $recommendation->post->id) }}"  class="btn comment-card">Learn More</></a>
+   </div>
+
+    </div>
+        </div>
+  </div>
+</a>
+ @endforeach
+@endif
+</div>
   <div class="row">
-    @for ($i = 0; $i < 8; $i++)
-        <div class="small_post col-md-3">
-            <div class="card">
-                <a href="#" >
-                  <img src="{{ asset('images/map_samples/post_pc_sample.png') }}" class="card-img-top" alt="Tourism Image">
-                </a>
-
-                <div class="card-body">
-
-                  <div class="row">
-                    <div class="col-auto">
-                      <h5 class="fw-bolder">Title</h5>
-                    </div>
-                    <div class="col-auto">
-                      <form action="#">
+    
+    @foreach ($posts as $post)
+      <div class="small_post col-md-3">
+        <div class="card">
+          
+          <a href="{{ route('post.show', ['id' => $post->id]) }}">
+  <img src="{{ $post->images->isNotEmpty() ? asset('storage/' . $post->images->first()->image_url) : asset('images/default.png') }}" class="card-img-top" alt="Tourism Image">
+</a>
+          
+        
+  <div class="card-body">
+    <div class="row">
+       <div class="col-auto">
+           <h5 class="fw-bolder">{{$post->title}}</h5>
+              </div>
+                  <div class="col-auto">
+                     <form action="#">
                         <button type="submit" class="btn btn-sm shadow-none p-0"><i class="fa-regular fa-heart"></i></button>
                       </form>
                     </div>
@@ -27,21 +98,24 @@
                     </div>
                   </div>
 
-                  <div class="row">
+                  
                     <div class="col-auto mb-1">
                       <span class="badge bg-secondary bg-opacity-50 rounded-pill">Category</span>
                       <span class="badge bg-secondary bg-opacity-50 rounded-pill">Category</span>
                     </div>
                   </div>
                   <div class="post_text">
-                    <p>text text text text text text text text text text text text text text text text text text text text</p>
+                    
                     <button class="btn comment-card">Learn More</button>
                    
                   </div>
               
-                </div>
             </div>
+         </div>
+          
+            @endforeach
         </div>
-    @endfor
   </div>
-</div>
+
+
+  

--- a/resources/views/post-spot/tourism-posts.blade.php
+++ b/resources/views/post-spot/tourism-posts.blade.php
@@ -1,22 +1,24 @@
-
 <div class="show_posts">
   <h3>Recommend</h3>
+  <div class="container">
   <div class="row">
-    @for ($i = 0; $i < 4; $i++)
-        <div class="small_post col-md-3">
-            <div class="card">
-                <a href="#" >
-                  <img src="{{ asset('images/map_samples/post_pc_sample.png') }}" class="card-img-top" alt="Tourism Image">
-                </a>
-
-                <div class="card-body">
-
-                  <div class="row">
-                    <div class="col-auto">
-                      <h5 class="fw-bolder">Title</h5>
-                    </div>
-                    <div class="col-auto">
-                      <form action="#">
+    
+    @foreach ($posts as $post)
+      <div class="small_post col-md-3">
+        <div class="card">
+          
+          <a href="{{ route('post.show', ['id' => $post->id]) }}">
+  <img src="{{ $post->images->isNotEmpty() ? asset('storage/' . $post->images->first()->image_url) : asset('images/default.png') }}" class="card-img-top" alt="Tourism Image">
+</a>
+          
+        
+  <div class="card-body">
+    <div class="row">
+       <div class="col-auto">
+           <h5 class="fw-bolder">{{$post->title}}</h5>
+              </div>
+                  <div class="col-auto">
+                     <form action="#">
                         <button type="submit" class="btn btn-sm shadow-none p-0"><i class="fa-regular fa-heart"></i></button>
                       </form>
                     </div>
@@ -27,22 +29,23 @@
                     </div>
                   </div>
 
-                  <div class="row">
+                  
                     <div class="col-auto mb-1">
                       <span class="badge bg-secondary bg-opacity-50 rounded-pill">Category</span>
                       <span class="badge bg-secondary bg-opacity-50 rounded-pill">Category</span>
                     </div>
                   </div>
                   <div class="post_text">
-                    <p>text text text text text text text text text text text text text text text text text text text text</p>
+                    
                     <button class="btn comment-card">Learn More</button>
                    
                   </div>
               
-                </div>
             </div>
+         </div>
+          
+            @endforeach
         </div>
-    @endfor
   </div>
 
 
@@ -52,7 +55,7 @@
         <div class="small_post col-md-3">
             <div class="card">
                 <a href="#" >
-                  <img src="{{ asset('images/map_samples/post_pc_sample.png') }}" class="card-img-top" alt="Tourism Image">
+                  <!-- <img src="{{ asset('images/map_samples/post_pc_sample.png') }}" class="card-img-top" alt="Tourism Image"> -->
                 </a>
 
                 <div class="card-body">

--- a/resources/views/post-spot/tourism-posts.blade.php
+++ b/resources/views/post-spot/tourism-posts.blade.php
@@ -1,6 +1,78 @@
 <div class="show_posts">
-  <h3>Recommend</h3>
   <div class="container">
+     <div class="row">
+      <!-- レコメンド機能 recommend -->
+          <h3>Recommended Tourism Posts</h3>
+            @if($tourismRecommendations->isEmpty())
+          <a href="{{ route('spot.show', $spot->id )}}" class="text-decoration-none">
+          <div class="col-12">
+               <p class="text-center text-danger">No recommendations available at the moment.</p>
+         </div>
+           <!-- card -->
+            @else
+            @foreach ($tourismRecommendations->take(4) as $recommendation)
+         <div class="small_post col-md-3">
+         <div class="card">
+               <a href="{{ route('post.show', $recommendation->post->id) }}">
+                  <img src="{{ asset('storage/' . $recommendation->post->images->first()->image_url) }}" class="card-img-top" alt="Post Image">
+               </a>
+        <!-- card body -->
+        <div class="card-body">
+            <div class="row">
+                <div class="col-auto">
+                    <h5 class="fw-bolder">{{ $recommendation->post->title }}</h5>
+               </div>
+        </div>
+        <div class="row d-flex justify-content-end pe-2">
+                      {{-- Likes --}}
+                    <div class="col-auto">
+                      <form action="{{ route('post.like', $recommendation->post->id ?? 1) }}" method="POST">
+                        @csrf
+                        <button type="submit" class="btn btn-sm shadow-none p-0" aria-label="like">
+                            <i class="fa-regular fa-heart {{ $recommendation->post->isLiked() ? 'active' : '' }}" id="like-icon"></i>
+                        </button>
+                        <span class="count-text ms-1" id="like-count">{{ $recommendation->post->likes->count() }}</span>
+                     </form>
+            </div>
+            <div class="col-auto p-0">
+                      <form action="{{ route('post.favorite', $recommendation->post->id ?? 1) }}" method="POST">
+                        @csrf
+                        <button type="submit" class="btn btn-sm shadow-none p-0" aria-label="star">
+                            <i class="fa-regular fa-star {{ $recommendation->post->isFavorited ? 'active' : '' }}" id="favorite-icon"></i>
+                        </button>
+                        <span class="count-text ms-1" id="favorite-count">{{ $recommendation->post->favorites->count() }}</span>
+                      </form>
+                
+            </div>
+          
+     </div>
+
+    <div class="row">
+         <div class="col-auto mb-1">
+          @foreach ($recommendation->post->categories as $category)
+          @if ($category->id == $recommendedCategory->id) <!-- レコメンドされたカテゴリのみ表示 -->
+              <span class="badge bg-secondary bg-opacity-50 rounded-pill">{{ $category->name }}</span>
+           @endif
+          @endforeach
+        </div>
+     </div>
+
+ <!-- 投稿の本文を制限して表示 -->
+  <div class="post_text">
+     <p>{{ Str::limit($recommendation->post->comments, 50) }}</p>
+<a href="{{ route('post.show', $recommendation->post->id) }}"  class="btn comment-card">Learn More</></a>
+   </div>
+
+    </div>
+        </div>
+  </div>
+</a>
+ @endforeach
+@endif
+</div>
+
+
+
   <div class="row">
     
     @foreach ($posts as $post)
@@ -49,48 +121,4 @@
   </div>
 
 
-  <h3>Tourism posts</h3>
-  <div class="row">
-    @for ($i = 0; $i < 8; $i++)
-        <div class="small_post col-md-3">
-            <div class="card">
-                <a href="#" >
-                  <!-- <img src="{{ asset('images/map_samples/post_pc_sample.png') }}" class="card-img-top" alt="Tourism Image"> -->
-                </a>
-
-                <div class="card-body">
-
-                  <div class="row">
-                    <div class="col-auto">
-                      <h5 class="fw-bolder">Title</h5>
-                    </div>
-                    <div class="col-auto">
-                      <form action="#">
-                        <button type="submit" class="btn btn-sm shadow-none p-0"><i class="fa-regular fa-heart"></i></button>
-                      </form>
-                    </div>
-                    <div class="col-auto p-0">
-                      <form action="#">
-                        <button type="submit" class="btn btn-sm shadow-none p-0"><i class="fa-regular fa-star"></i></button>
-                      </form>
-                    </div>
-                  </div>
-
-                  <div class="row">
-                    <div class="col-auto mb-1">
-                      <span class="badge bg-secondary bg-opacity-50 rounded-pill">Category</span>
-                      <span class="badge bg-secondary bg-opacity-50 rounded-pill">Category</span>
-                    </div>
-                  </div>
-                  <div class="post_text">
-                    <p>text text text text text text text text text text text text text text text text text text text text</p>
-                    <button class="btn comment-card">Learn More</button>
-                   
-                  </div>
-              
-                </div>
-            </div>
-        </div>
-    @endfor
-  </div>
-</div>
+  

--- a/routes/web.php
+++ b/routes/web.php
@@ -71,9 +71,8 @@ Route::get('/admin-create_category', function () {
 });
 
 
-Route::get('/tourism', function () {
-    return view('display.tourism');
-});
+Route::get('/tourism', [PostController::class, 'showTourismPosts'])->name('display.tourism');
+
 
 Route::get('/events-tourism', function () {
     return view('display.events-tourism');

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,10 +22,7 @@ use App\Http\Controllers\RecommendationController;
 
 // Home Route
 Route::get('/', [HomeController::class, 'index'])->name('home');
-// Events and Tourism Routes
-Route::get('/events', function () {
-    return view('display.events');
-});
+
 Route::get('/admin-users-index', function () {
     return view('admin/users/users-index');
 });
@@ -57,8 +54,17 @@ Route::get('/admin-create_category', function () {
     return view('/admin/modals/create_category');
 });
 
+// Events and Tourism Routes
+
+
+Route::get('/events', [PostController::class, 'showEventsPosts'])->name('display.events');
+
 
 Route::get('/tourism', [PostController::class, 'showTourismPosts'])->name('display.tourism');
+
+Route::get('/tourism-category/{category_id}', [PostController::class, 'showCategoryTourismPosts'])->name('tourism.category');
+
+Route::get('/events-category/{category_id}', [PostController::class, 'showCategoryEventsPosts'])->name('events.category');
 
 
 Route::get('/events-tourism', function () {
@@ -202,13 +208,9 @@ Route::group(["middleware"=> "auth"], function(){
 // Search Routes
 Route::get('/search', [SearchController::class, 'index'])->name('search');
 
-Route::get('/events', function () {
-    return view('display.events'); // 実際のビューのパスに合わせて修正してください
-})->name('events'); // 名前を付けることで、route('events') で参照可能になります。
 
-Route::get('/tourism', function () {
-    return view('display.tourism'); // 実際のビューのパスに合わせて修正してください
-})->name('tourism'); // 名前を付けることで、route('tourism') で参照可能になります。
+
+
 // Serch function
 Route::get('/search', [SearchController::class, 'search'])->name('search');
 


### PR DESCRIPTION
[Backend/display-posts-on-event-tourism] partial display-posts-on-event-tourism

Changed
-events.blade.php and tourism.blade.php
 ・Added a link to the map image.
 ・Display by category.

-event.css and tourism.css
 ・Arrange the categories horizontally, allowing subcategories to be selected by hovering over the parent category
 
-event-posts.blade.php and tourism-posts.blade.php
 ・Display recommended posts.
-PostController
 ・Display recommended posts and filter by category for display.
-web.php
 ・Recommendation and category features