### PR TITLE
[Backend/display-posts-on-event-tourism] partial display-posts-on-eve…

### DIFF
--- a/public/css/events.css
+++ b/public/css/events.css
@@ -237,10 +237,14 @@ body {
   background-color: #90AFC5;
 }
 
-/* posts */
+
+/* Posts Section------------------------------------------------*/
+
 .small_post .card{
   box-shadow: 0px 4px 10px rgba(0, 0, 0, .25);
   margin-bottom: 60px;
+  overflow: hidden;
+  border-radius: 10px; /* 角を丸くする */
   height: 100%;
 }
 
@@ -251,10 +255,83 @@ body {
   object-fit: cover
 }
 
+/* .small_post img:hover {
+  opacity: 0.7;
+} */
+
+
 .post_text p {
   position: relative;
   max-height: 50px; /* 開く前に見せたい高さを指定 */
   margin-bottom: 0;
   overflow: hidden;
   /* transition: max-height 1s; */
+}
+
+
+.post_text button {
+  height: 40px; /* 高さを調整 */
+  padding: 10px 15px; /* ボタンの内側の余白 */
+  background-color: #336B87; /* ボタンの背景色 */
+  color: #ffffff; /* ボタンのテキスト色 */
+  border: none; /* ボタンの境界線を無効にする */
+  border-radius: 10px; /* 角を丸くする */
+  cursor: pointer; /* カーソルをポインターに変更 */
+}
+
+.post_text a button:hover {
+    background-color: #90AFC5; /* ホバー時の背景色 */
+    color: #2A3132; /* ボタンのテキスト色 */
+}
+
+
+/* postの高さを揃える */
+.show_posts .row {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.small_post {
+  display: flex;
+  flex-direction: column;
+}
+
+.card {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.card-body {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
+.post_text {
+  margin-top: auto; /* ボタンを下部に固定する */
+}
+
+.no-posts-message {
+  text-align: center;
+  font-size: 1.5em;
+  color: #FF0000; /* Red color for visibility */
+  font-weight: bold;
+  margin-top: 20px;
+  padding: 10px;
+}
+
+
+
+/* Icons ------------------------------------------------*/
+
+/* Likeされた状態の色 */
+#like-icon.active {
+  color: red;
+}
+
+/* Favoriteされた状態の色 */
+#favorite-icon.active {
+  color: gold;
 }

--- a/public/css/tourism.css
+++ b/public/css/tourism.css
@@ -247,6 +247,11 @@ opacity: 0.8; /* 不透明度を下げる */
   object-fit: cover
 }
 
+/* .small_post img:hover {
+  opacity: 0.7;
+} */
+
+
 .post_text p {
   position: relative;
   max-height: 50px; /* 開く前に見せたい高さを指定 */
@@ -269,4 +274,55 @@ opacity: 0.8; /* 不透明度を下げる */
 .post_text a button:hover {
     background-color: #90AFC5; /* ホバー時の背景色 */
     color: #2A3132; /* ボタンのテキスト色 */
+}
+
+
+/* postの高さを揃える */
+.show_posts .row {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.small_post {
+  display: flex;
+  flex-direction: column;
+}
+
+.card {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.card-body {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
+.post_text {
+  margin-top: auto; /* ボタンを下部に固定する */
+}
+
+.no-posts-message {
+  text-align: center;
+  font-size: 1.5em;
+  color: #FF0000; /* Red color for visibility */
+  font-weight: bold;
+  margin-top: 20px;
+  padding: 10px;
+}
+
+
+/* Icons ------------------------------------------------*/
+
+/* Likeされた状態の色 */
+#like-icon.active {
+  color: red;
+}
+
+/* Favoriteされた状態の色 */
+#favorite-icon.active {
+  color: gold;
 }

--- a/resources/views/display/events.blade.php
+++ b/resources/views/display/events.blade.php
@@ -27,7 +27,7 @@
     <div class="row justify-content-center">
         <div class="col-md-9">
             <div class="spot-banner">
-                <a href="{{route('map.page')}}">
+                <a href="{{ route('map.page', ['keyword' => request('keyword')]) }}">
                     <img src="{{ asset('images/map.png')}}"
                     class="spot-banner-img mx-auto d-block" alt="map pictures">
                     <div class="spot-banner-text">
@@ -38,11 +38,11 @@
 
             {{-- Search Bar --}}
             <div class="search-container d-flex justify-content-center">
-                <form class="d-flex mb-4" role="search">
-                    <input class="form-control form-control-lg me-2" type="search" aria-label="Search">
-                    <i class="fas fa-search icon_size"></i>
-                    <button class="btn fs-3 fw-bold" type="submit">Search</button>
+                  <form class="d-flex mb-4" role="search"     method="GET" action="{{ route('events.posts.search') }}">
+                     <input class="form-control form-control-lg me-2" type="search" name="keyword" aria-label="Search" value="{{ request('keyword') }}">
+                     <button class="btn fs-3 fw-bold" type="submit">Search</button>
                 </form>
+          
             </div>
 
            <!-- category part -->

--- a/resources/views/display/tourism.blade.php
+++ b/resources/views/display/tourism.blade.php
@@ -19,7 +19,7 @@
             </div> 
     
             <div class="spot-banner">
-                <a href="{{ route('map.page')}}">
+                <a href="{{ route('map.page', ['keyword' => request('keyword')]) }}">
                     <img src="{{asset('images/map.png')}}" class="spot-banner-img mx-auto d-block" alt="map pictures">
                     <div class="spot-banner-text">
                             <h2>Spots near You</h2>
@@ -30,11 +30,11 @@
 
              {{-- Search Bar --}}
              <div class="search-container d-flex justify-content-center">
-                <form class="d-flex mb-4" role="search">
-                    <input class="form-control form-control-lg me-2" type="search" aria-label="Search">
-                    <i class="fas fa-search icon_size"></i>
-                    <button class="btn fs-3 fw-bold" type="submit">Search</button>
+                  <form class="d-flex mb-4" role="search"     method="GET" action="{{ route('tourism.posts.search') }}">
+                     <input class="form-control form-control-lg me-2" type="search" name="keyword" aria-label="Search" value="{{ request('keyword') }}">
+                     <button class="btn fs-3 fw-bold" type="submit">Search</button>
                 </form>
+          
             </div>
 
             <!-- category part -->

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -49,13 +49,13 @@
         <!-- Event and Tourism Display  -->
         <div class="image-container">
             <div class="image-item">
-              <a href="{{ route('events') }}"> <!-- イベントページへのリンク -->
+              <a href="{{ route('display.events') }}"> <!-- イベントページへのリンク -->
                  <img src="images/event-link.png" alt="Event Page">
                  <div class="overlay-text">Event Page</div>
               </a>
             </div>
             <div class="image-item">
-               <a href="{{ route('tourism') }}"> <!-- ツーリズムページへのリンク -->
+               <a href="{{ route('display.tourism') }}"> <!-- ツーリズムページへのリンク -->
                   <img src="images/tourism-link.png" alt="Tourism Page">
                   <div class="overlay-text">Tourism Page</div>
                </a>

--- a/resources/views/post-spot/event-posts.blade.php
+++ b/resources/views/post-spot/event-posts.blade.php
@@ -57,11 +57,14 @@
         </div>
      </div>
 
- <!-- 投稿の本文を制限して表示 -->
-  <div class="post_text">
-     <p>{{ Str::limit($recommendation->post->comments, 50) }}</p>
-<a href="{{ route('post.show', $recommendation->post->id) }}"  class="btn comment-card">Learn More</></a>
-   </div>
+ 
+ <div class="post_text">
+     <p class="mb-2">{{ $recommendation->post->comments ?? '' }}</p>
+      <a href="{{ route('post.show', $recommendation->post->id )}}" >
+           <button class="btn comment-card">Learn More</button>
+     </a>
+ </div>
+              
 
     </div>
         </div>
@@ -70,52 +73,109 @@
  @endforeach
 @endif
 </div>
+
+<!-- レコメンド以外で表示するポスト -->
+
+<div class="row">
+        <div class="col-md-11 event-content">
+           <!-- カテゴリ名または「検索結果」を表示 -->
+           <div>
+               @if(isset($selectedCategory))
+                   <h2>Posts related to   
+                     {{$selectedCategory->name }} </h2>
+               @elseif(request('keyword'))
+                   <h2>Seaech results</h2>
+               @endif
+           </div>
+
+<div class="show_posts">
   <div class="row">
-    
-    @foreach ($posts as $post)
-      <div class="small_post col-md-3">
-        <div class="card">
-          
-          <a href="{{ route('post.show', ['id' => $post->id]) }}">
-  <img src="{{ $post->images->isNotEmpty() ? asset('storage/' . $post->images->first()->image_url) : asset('images/default.png') }}" class="card-img-top" alt="Tourism Image">
-</a>
-          
-        
-  <div class="card-body">
-    <div class="row">
-       <div class="col-auto">
-           <h5 class="fw-bolder">{{$post->title}}</h5>
-              </div>
-                  <div class="col-auto">
-                     <form action="#">
-                        <button type="submit" class="btn btn-sm shadow-none p-0"><i class="fa-regular fa-heart"></i></button>
-                      </form>
-                    </div>
-                    <div class="col-auto p-0">
-                      <form action="#">
-                        <button type="submit" class="btn btn-sm shadow-none p-0"><i class="fa-regular fa-star"></i></button>
-                      </form>
+      @if($posts->isEmpty())
+      <!-- 投稿が存在しない場合のメッセージ -->
+       <div class="col-11 text-center no-posts-message">
+           <h3>No related posts available.</h3>
+      </div>
+      @else
+       @foreach($posts as $post) <!-- 各スポットに紐づくポストをループ -->
+        <div class="small_post col-md-3">
+          <a href="{{ route('post.show', $post->id )}}" class="text-decoration-none text-black">
+            <div class="card">
+              
+                @if ($post->images->isNotEmpty() && $post->images->first())
+                    <img src="{{ asset('storage/' . $post->images->first()->image_url) }}" class="card-img-top" alt="Tourism Image">
+                @else
+                    <img src="{{ asset('images/map_samples/post_pc_sample.png') }}" class="card-img-top" alt="Default Image">
+                @endif
+              
+
+                <div class="card-body">
+
+                  <div class="row">
+                    <div class="col-auto">
+                      <h5 class="fw-bolder post_title text-truncate">{{ $post->title }}</h5>
                     </div>
                   </div>
 
-                  
-                    <div class="col-auto mb-1">
-                      <span class="badge bg-secondary bg-opacity-50 rounded-pill">Category</span>
-                      <span class="badge bg-secondary bg-opacity-50 rounded-pill">Category</span>
+
+                  <div class="row d-flex justify-content-end pe-2">
+                      {{-- Likes --}}
+                    <div class="col-auto">
+                      <form action="{{ route('post.like', $post->id ?? 1) }}" method="POST">
+                        @csrf
+                        <button type="submit" class="btn btn-sm shadow-none p-0" aria-label="like">
+                            <i class="fa-regular fa-heart {{ $post->isLiked() ? 'active' : '' }}" id="like-icon"></i>
+                        </button>
+                        <span class="count-text ms-1" id="like-count">{{ $post->likes->count() }}</span>
+                    </form>
+                      {{-- <form action="#">
+                        <button type="submit" class="btn btn-sm shadow-none p-0"><i class="fa-regular fa-heart"></i></button>
+                      </form> --}}
+                    </div>
+
+                    {{-- Favorites --}}
+                    <div class="col-auto p-0">
+                      <form action="{{ route('post.favorite', $post->id ?? 1) }}" method="POST">
+                        @csrf
+                        <button type="submit" class="btn btn-sm shadow-none p-0" aria-label="star">
+                            <i class="fa-regular fa-star {{ $post->isFavorited ? 'active' : '' }}" id="favorite-icon"></i>
+                        </button>
+                        <span class="count-text ms-1" id="favorite-count">{{ $post->favorites->count() }}</span>
+                      </form>
+                      {{-- <form action="#">
+                        <button type="submit" class="btn btn-sm shadow-none p-0"><i class="fa-regular fa-star"></i></button>
+                      </form> --}}
                     </div>
                   </div>
-                  <div class="post_text">
                     
-                    <button class="btn comment-card">Learn More</button>
+                  
+
+                  <!-- Category表示部分 -->
+                  <div class="row">
+                    <div class="col-auto mb-1">
+                      @foreach($post->categories as $category)
+                        <span class="badge bg-secondary bg-opacity-50 rounded-pill">{{ $category->name }}</span>
+                      @endforeach
+                    </div>
+                  </div>
+
+                  <!-- comments部分 & Buttno -->
+                  <div class="post_text">
+                    <p class="mb-2">{{ $post->comments ?? '' }}</p>
+                    <a href="{{ route('post.show', $post->id )}}" >
+                      <button class="btn comment-card">Learn More</button>
+                    </a>
                    
                   </div>
               
+                </div>
             </div>
-         </div>
-          
-            @endforeach
+          </a>
         </div>
-  </div>
+        @endforeach
+        @endif
 
+   
+  </div>
+</div>
 
   

--- a/resources/views/post-spot/tourism-posts.blade.php
+++ b/resources/views/post-spot/tourism-posts.blade.php
@@ -58,10 +58,13 @@
      </div>
 
  <!-- 投稿の本文を制限して表示 -->
-  <div class="post_text">
-     <p>{{ Str::limit($recommendation->post->comments, 50) }}</p>
-<a href="{{ route('post.show', $recommendation->post->id) }}"  class="btn comment-card">Learn More</></a>
-   </div>
+ <div class="post_text">
+     <p class="mb-2">{{ $recommendation->post->comments ?? '' }}</p>
+      <a href="{{ route('post.show', $recommendation->post->id )}}" >
+           <button class="btn comment-card">Learn More</button>
+     </a>
+ </div>
+           
 
     </div>
         </div>
@@ -72,53 +75,105 @@
 </div>
 
 
+<div class="row">
+        <div class="col-md-11 event-content">
+           <!-- カテゴリ名または「検索結果」を表示 -->
+           <div>
+               @if(isset($selectedCategory))
+                   <h2>Posts related to  {{$selectedCategory->name }} </h2>
+               @elseif(request('keyword'))
+                   <h2>Seaech results</h2>
+               @endif
+           </div>
 
+<div class="show_posts">
   <div class="row">
-    
-    @foreach ($posts as $post)
-      <div class="small_post col-md-3">
-        <div class="card">
-          
-          <a href="{{ route('post.show', ['id' => $post->id]) }}">
-  <img src="{{ $post->images->isNotEmpty() ? asset('storage/' . $post->images->first()->image_url) : asset('images/default.png') }}" class="card-img-top" alt="Tourism Image">
-</a>
-          
-        
-  <div class="card-body">
-    <div class="row">
-       <div class="col-auto">
-           <h5 class="fw-bolder">{{$post->title}}</h5>
-              </div>
-                  <div class="col-auto">
-                     <form action="#">
-                        <button type="submit" class="btn btn-sm shadow-none p-0"><i class="fa-regular fa-heart"></i></button>
-                      </form>
-                    </div>
-                    <div class="col-auto p-0">
-                      <form action="#">
-                        <button type="submit" class="btn btn-sm shadow-none p-0"><i class="fa-regular fa-star"></i></button>
-                      </form>
+  @if($posts->isEmpty())
+      <!-- 投稿が存在しない場合のメッセージ -->
+       <div class="col-11 text-center no-posts-message">
+           <h3>No related posts available.</h3>
+      </div>
+      @else
+        @foreach($posts as $post) <!-- 各スポットに紐づくポストをループ -->
+        <div class="small_post col-md-3">
+          <a href="{{ route('post.show', $post->id )}}" class="text-decoration-none text-black">
+            <div class="card">
+              
+                @if ($post->images->isNotEmpty() && $post->images->first())
+                    <img src="{{ asset('storage/' . $post->images->first()->image_url) }}" class="card-img-top" alt="Tourism Image">
+                @else
+                    <img src="{{ asset('images/map_samples/post_pc_sample.png') }}" class="card-img-top" alt="Default Image">
+                @endif
+              
+
+                <div class="card-body">
+
+                  <div class="row">
+                    <div class="col-auto">
+                      <h5 class="fw-bolder post_title text-truncate">{{ $post->title }}</h5>
                     </div>
                   </div>
 
-                  
-                    <div class="col-auto mb-1">
-                      <span class="badge bg-secondary bg-opacity-50 rounded-pill">Category</span>
-                      <span class="badge bg-secondary bg-opacity-50 rounded-pill">Category</span>
+
+                  <div class="row d-flex justify-content-end pe-2">
+                      {{-- Likes --}}
+                    <div class="col-auto">
+                      <form action="{{ route('post.like', $post->id ?? 1) }}" method="POST">
+                        @csrf
+                        <button type="submit" class="btn btn-sm shadow-none p-0" aria-label="like">
+                            <i class="fa-regular fa-heart {{ $post->isLiked() ? 'active' : '' }}" id="like-icon"></i>
+                        </button>
+                        <span class="count-text ms-1" id="like-count">{{ $post->likes->count() }}</span>
+                    </form>
+                      {{-- <form action="#">
+                        <button type="submit" class="btn btn-sm shadow-none p-0"><i class="fa-regular fa-heart"></i></button>
+                      </form> --}}
+                    </div>
+
+                    {{-- Favorites --}}
+                    <div class="col-auto p-0">
+                      <form action="{{ route('post.favorite', $post->id ?? 1) }}" method="POST">
+                        @csrf
+                        <button type="submit" class="btn btn-sm shadow-none p-0" aria-label="star">
+                            <i class="fa-regular fa-star {{ $post->isFavorited ? 'active' : '' }}" id="favorite-icon"></i>
+                        </button>
+                        <span class="count-text ms-1" id="favorite-count">{{ $post->favorites->count() }}</span>
+                      </form>
+                      {{-- <form action="#">
+                        <button type="submit" class="btn btn-sm shadow-none p-0"><i class="fa-regular fa-star"></i></button>
+                      </form> --}}
                     </div>
                   </div>
-                  <div class="post_text">
                     
-                    <button class="btn comment-card">Learn More</button>
+                  
+
+                  <!-- Category表示部分 -->
+                  <div class="row">
+                    <div class="col-auto mb-1">
+                      @foreach($post->categories as $category)
+                        <span class="badge bg-secondary bg-opacity-50 rounded-pill">{{ $category->name }}</span>
+                      @endforeach
+                    </div>
+                  </div>
+
+                  <!-- comments部分 & Buttno -->
+                  <div class="post_text">
+                    <p class="mb-2">{{ $post->comments ?? '' }}</p>
+                    <a href="{{ route('post.show', $post->id )}}" >
+                      <button class="btn comment-card">Learn More</button>
+                    </a>
                    
                   </div>
               
+                </div>
             </div>
-         </div>
-          
-            @endforeach
+          </a>
         </div>
-  </div>
+        @endforeach
+        @endif
 
+   
+  </div>
+</div>
 
   

--- a/routes/web.php
+++ b/routes/web.php
@@ -63,12 +63,18 @@ Route::get('/admin-create_category', function () {
 
 Route::get('/events', [PostController::class, 'showEventsPosts'])->name('display.events');
 
+Route::get('/events-category/{category_id}', [PostController::class, 'showCategoryEventsPosts'])->name('events.category');
+
+Route::get('/events-posts/search', [PostController::class, 'searchEventsPosts'])->name('events.posts.search');
+
+
 
 Route::get('/tourism', [PostController::class, 'showTourismPosts'])->name('display.tourism');
 
 Route::get('/tourism-category/{category_id}', [PostController::class, 'showCategoryTourismPosts'])->name('tourism.category');
 
-Route::get('/events-category/{category_id}', [PostController::class, 'showCategoryEventsPosts'])->name('events.category');
+Route::get('/tourism-posts/search', [PostController::class, 'searchTourismPosts'])->name('tourism.posts.search');
+
 
 
 Route::get('/events-tourism', function () {
@@ -231,11 +237,7 @@ Route::get('/search', [SearchController::class, 'search'])->name('search');
  Route::delete('/comment/{id}', [CommentController::class, 'destroy'])->name('comment.destroy');
  
 
-// イベントページへのルート
-Route::get('/events', [EventController::class, 'index'])->name('events');
 
-// ツーリズムページへのルート
-Route::get('/tourism', [TourismController::class, 'index'])->name('tourism');
  
 //Serch function
 Route::get('/search', [SearchController::class, 'search'])->name('search');


### PR DESCRIPTION
…nt-tourism

Changed
-events.blade.php and tourism.blade.php
 ・Display posts searched by keyword
 ・Keep the keyword when navigating to a different page.

-event.css and tourism.css
 ・Arrange the categories horizontally, allowing subcategories to 　　be selected by hovering over the parent category
 ・Adjust the post layout.

-event-posts.blade.php and tourism-posts.blade.php
 ・Adjust the layout of posts displayed during search and category selection.

-PostController
 ・Specify the search keyword and retrieve post data.
-web.php
 ・Route for the search functionality